### PR TITLE
Add ng tags input

### DIFF
--- a/bin/convert-to-ng-tags-input.js
+++ b/bin/convert-to-ng-tags-input.js
@@ -1,0 +1,83 @@
+(function () {
+  var mongoose = require('mongoose')
+  mongoose.connect('mongodb://localhost:27017/ExpTracker')
+  require('../models/expenses')
+  var Expense = mongoose.model('Expense')
+
+  /* I want to convert tags which is an array 
+   * into an array of objects with text: tag */
+
+  // Define some testTags variables
+  // Can delete this section once finished testing
+  var testTagsSource = [ "tag1"
+                       , "tag2"
+                       , "tag3"
+                       ]
+    , testTagsDest = []
+  
+  // Take a string and make an object with field text: <string>
+  convertToObject = function (text) {
+    var tagObj = { "text" : "sampleTag" }
+
+    tagObj.text = text
+    return tagObj
+  }
+
+  // Take an array and for every item in it, call convert to Obj
+  convertTags = function (sourceArray, destArray) {
+    for (var i = 0; i < sourceArray.length; i++) {
+      destArray.push(convertToObject(sourceArray[i]))
+    };
+  }
+
+  // Grab all expenses from DB that don't have an ngTags field
+  Expense.find( { "ngTags" : { "$exists" : false } }, function (err, expenses) {
+    var newTags = []
+      , expToSave = {}
+      , oldRecordId = {}
+
+    if (err) { console.log(err + ': error finding record') };
+    
+    // for each expense in the dataset
+    expenses.forEach(function (element, index, array) {
+      // Reset newTags to null array
+      newTags = []
+
+      // convert existing tags into objects
+      convertTags(element.tags, newTags)
+
+      // save new tags object into expense schema
+      element.ngTags = newTags
+
+      // Updating isn't working due to some strange "feature w/ schemas"
+      // Save existing record schema ID and use it to delete the old
+      // record after new ones have been created
+      oldRecordId = element._id
+      element._id = null
+
+      // save exepense back into database
+      expToSave = new Expense(element)
+      expToSave.save(function () {
+        if (err) { console.log(err + ': Error saving record') };
+
+        console.log('Saved to DB: ' + expToSave)
+
+        // now remove the prior entry in the db that doesn't have the new 
+        // ngTags field -- Removing worked better in the 
+        /*Expense.findByIdAndRemove(oldRecordId, function () {
+          console.log('Old record removed: ' + oldRecordId)*/
+        })
+
+      })  
+    })
+  })
+})()
+
+/*// code to insert into mongodb client
+db.expenses.find( { tags : "test" } ).forEach(function (doc) {
+  ngTags = [ { "text" : "test"
+             , "text" : "ngTag-test"
+           } ];
+
+  db.expenses.save(doc);
+})*/

--- a/bin/tagCleanUpBlanks.js
+++ b/bin/tagCleanUpBlanks.js
@@ -1,0 +1,39 @@
+(function() {
+	var mongoose = require('mongoose');
+	mongoose.connect('mongodb://localhost:27017/ExpTracker');
+	require('../models/expenses');
+	var Expense = mongoose.model('Expense');
+
+	console.log('connected to DB and initialized');
+	var blankTags = 1; /* Assume blank tags exist to start */
+
+	Expense.find({ tags : '' }, function (err, data) {
+		if (err) { console.log(err + ': error searching database'); };
+		if (!data) {
+			console.log('No blank tags found'); 
+			blankTags = 0;
+			process.exit;
+		};
+		console.log(data.length + ' objects returned with blank tags');
+		console.log(data);
+
+
+		data.forEach(function (element, index, array) {
+			while(element.tags.indexOf('') >= 0) {
+				element.tags.splice(element.tags.indexOf(''),1);
+			};
+			Expense.findById(element._id, function (err, expense) {
+				console.log('expense - ' + expense.tags);
+				console.log('element - ' + element.tags);
+				expense.tags = element.tags;
+				expense.save(function (err, expense, numAffected) {
+					if (err) { console.log(err)};
+					console.log(numAffected + ' record(s) updated')
+				});
+
+			});
+		});
+	});
+})();
+
+

--- a/models/expenses.js
+++ b/models/expenses.js
@@ -1,15 +1,15 @@
 var mongoose = require('mongoose');
 
-var ExpenseSchema = new mongoose.Schema({
-	importance: String,
-	paidTo: String,
-	tags: Array,
-	amount: Number,
-	memo: String,
-	dateIncurred: Date,
-	dateEntered: Date,
-	entrySource: String,
-	transactionType: String
+var ExpenseSchema = new mongoose.Schema( { importance: String
+	                                       , paidTo: String
+                                         , tags: Array
+                                         , amount: Number
+                                         , memo: String
+                                         , dateIncurred: Date
+                                         , dateEntered: Date
+                                         , entrySource: String
+                                         , transactionType: String
+                                         , ngTags: Array
 });
 
 mongoose.model('Expense', ExpenseSchema);

--- a/npm-debug.log
+++ b/npm-debug.log
@@ -1,29 +1,37 @@
 0 info it worked if it ends with ok
-1 verbose cli [ 'C:\\Program Files\\nodejs\\\\node.exe',
-1 verbose cli   'C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js',
+1 verbose cli [ 'node',
+1 verbose cli   'C:\\Users\\CB\\AppData\\Roaming\\npm\\node_modules\\npm\\bin\\npm-cli.js',
 1 verbose cli   'start' ]
-2 info using npm@1.4.28
+2 info using npm@2.3.0
 3 info using node@v0.10.35
-4 verbose node symlink C:\Program Files\nodejs\\node.exe
-5 verbose run-script [ 'prestart', 'start', 'poststart' ]
-6 info prestart ExpTracker@0.0.2
-7 info start ExpTracker@0.0.2
-8 verbose unsafe-perm in lifecycle true
-9 info ExpTracker@0.0.2 Failed to exec start script
-10 error ExpTracker@0.0.2 start: `node ./bin/www`
-10 error Exit status 8
-11 error Failed at the ExpTracker@0.0.2 start script.
-11 error This is most likely a problem with the ExpTracker package,
-11 error not with npm itself.
-11 error Tell the author that this fails on your system:
-11 error     node ./bin/www
-11 error You can get their info via:
-11 error     npm owner ls ExpTracker
-11 error There is likely additional logging output above.
-12 error System Windows_NT 6.1.7601
-13 error command "C:\\Program Files\\nodejs\\\\node.exe" "C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js" "start"
-14 error cwd C:\Users\CB\Documents\Programming\NODE\ExpTracker
-15 error node -v v0.10.35
-16 error npm -v 1.4.28
-17 error code ELIFECYCLE
-18 verbose exit [ 1, true ]
+4 verbose run-script [ 'prestart', 'start', 'poststart' ]
+5 info prestart ExpTracker@0.0.3
+6 info start ExpTracker@0.0.3
+7 verbose unsafe-perm in lifecycle true
+8 info ExpTracker@0.0.3 Failed to exec start script
+9 verbose stack Error: ExpTracker@0.0.3 start: `node ./bin/www`
+9 verbose stack Exit status 8
+9 verbose stack     at EventEmitter.<anonymous> (C:\Users\CB\AppData\Roaming\npm\node_modules\npm\lib\utils\lifecycle.js:213:16)
+9 verbose stack     at EventEmitter.emit (events.js:98:17)
+9 verbose stack     at ChildProcess.<anonymous> (C:\Users\CB\AppData\Roaming\npm\node_modules\npm\lib\utils\spawn.js:14:12)
+9 verbose stack     at ChildProcess.emit (events.js:98:17)
+9 verbose stack     at maybeClose (child_process.js:766:16)
+9 verbose stack     at Process.ChildProcess._handle.onexit (child_process.js:833:5)
+10 verbose pkgid ExpTracker@0.0.3
+11 verbose cwd C:\Users\CB\Documents\Programming\NODE\ExpTracker
+12 error Windows_NT 6.1.7601
+13 error argv "node" "C:\\Users\\CB\\AppData\\Roaming\\npm\\node_modules\\npm\\bin\\npm-cli.js" "start"
+14 error node v0.10.35
+15 error npm  v2.3.0
+16 error code ELIFECYCLE
+17 error ExpTracker@0.0.3 start: `node ./bin/www`
+17 error Exit status 8
+18 error Failed at the ExpTracker@0.0.3 start script 'node ./bin/www'.
+18 error This is most likely a problem with the ExpTracker package,
+18 error not with npm itself.
+18 error Tell the author that this fails on your system:
+18 error     node ./bin/www
+18 error You can get their info via:
+18 error     npm owner ls ExpTracker
+18 error There is likely additional logging output above.
+19 verbose exit [ 1, true ]

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "mongodb": "*",
     "mongoose": "*",
     "morgan": "~1.5.1",
+    "ng-tags-input": "^2.1.1",
     "serve-favicon": "~2.2.0"
   }
 }

--- a/public/javascripts/AngularApp.js
+++ b/public/javascripts/AngularApp.js
@@ -217,7 +217,7 @@
 					$log.log(id);
 					$http.get('/expenses/' + id).success(function (data) {
 						monthly.detailExpense = data;
-						monthly.detailExpense.tagsInput = '';
+						// monthly.detailExpense.tagsInput = '';
 						monthly.detailExpense.dateInput =  moment(monthly.detailExpense.dateIncurred).toDate();
 						monthly.detailExpense.tags.forEach(function (element, index, array) {
 							monthly.detailExpense.tagsInput += (element + ' ');
@@ -242,12 +242,12 @@
 					$log.log('Editing record: ' + id);
 					
 					// transform dateIncurred and tags from form values
-					monthly.detailExpense.tags = monthly.detailExpense.tagsInput.split(' ');
-					while(monthly.detailExpense.tags.indexOf('') >= 0) {
-						// element.tags.splice(element.tags.indexOf(''),1);
-						monthly.detailExpense.tags.splice(monthly.detailExpense.tags.indexOf(''),1);
+					// convert ngTags into legacy tags
+					monthly.detailExpense.tags = [ ];
+					for (var i = 0; i < monthly.detailExpense.ngTags.length; i++) {
+						monthly.detailExpense.tags.push(monthly.detailExpense.ngTags[i].text);
 					};
-					// monthly.detailExpense.tags.splice(monthly.detailExpense.tags.indexOf(''),1);
+
 					$log.log(monthly.detailExpense.tags);
 					monthly.detailExpense.dateIncurred = moment(monthly.detailExpense.dateInput).toDate();
 					monthly.detailExpense.amount = Number(monthly.detailExpense.amount);
@@ -312,11 +312,7 @@
 					$log.log(id);
 					$http.get('/expenses/' + id).success(function (data) {
 						expDetCtrl.expense = data;
-						expDetCtrl.expense.tagsInput = '';
 						expDetCtrl.expense.dateInput =  moment(expDetCtrl.expense.dateIncurred).toDate();
-						expDetCtrl.expense.tags.forEach(function (element, index, array) {
-							expDetCtrl.expense.tagsInput += (element + ' ');
-						});
 						expDetCtrl.expense.allowDelete = 0;
 						$log.log(expDetCtrl.expense);
 					});
@@ -326,12 +322,12 @@
 					$log.log('Editing record: ' + id);
 					
 					// transform dateIncurred and tags from form values
-					this.expense.tags = this.expense.tagsInput.split(' ');
-					while(this.expense.tags.indexOf('') >= 0) {
-						// element.tags.splice(element.tags.indexOf(''),1);
-						this.expense.tags.splice(this.expense.tags.indexOf(''),1);
+					// convet ngTags into legacy tags
+					expDetCtrl.expense.tags = [ ];
+					for (var i = 0; i < expDetCtrl.expense.ngTags.length; i++) {
+						expDetCtrl.expense.tags.push(expDetCtrl.expense.ngTags[i].text)
 					};
-					// this.expense.tags.splice(this.expense.tags.indexOf(''),1);
+
 					$log.log(this.expense.tags);
 					this.expense.dateIncurred = moment(this.expense.dateInput).toDate();
 					this.expense.amount = Number(this.expense.amount);
@@ -355,7 +351,7 @@
 			controller: function ($http,$log) {
 				this.expense = {};
 				this.expense.tags = [];
-				this.expenses.ngTags = [];
+				this.expense.ngTags = [];
 
 				// $log.log(this.today)
 
@@ -364,8 +360,8 @@
 					this.expense.amount = Number(this.expense.amount);
 
 					// convert ngTags into legacy tags
-					for (var i = 0; i < ngTags.length; i++) {
-						this.expense.tags.push(ngTags[i].text);
+					for (var i = 0; i < this.expense.ngTags.length; i++) {
+						this.expense.tags.push(this.expense.ngTags[i].text);
 					};
 					
 					this.expense.entrySource = 'web-app';
@@ -380,6 +376,8 @@
 							$log.log(tracker);
 						});
 					});
+
+
 
 					// reset form
 					this.expense = {};

--- a/public/javascripts/AngularApp.js
+++ b/public/javascripts/AngularApp.js
@@ -261,6 +261,10 @@
 					});
 				};
 
+				this.loadTags = function (query) {
+					return $http.get('/expenses/ngtaglist?text=' + query)
+				}
+
 				monthly.refresh();
 			},
 			controllerAs: 'monthlyExp'
@@ -339,6 +343,10 @@
 					});
 				};
 
+				this.loadTags = function (query) {
+					return $http.get('/expenses/ngtaglist?text=' + query)
+				}
+
 			},
 			controllerAs: "expDetCtrl"
 		};
@@ -382,6 +390,10 @@
 					// reset form
 					this.expense = {};
 				};
+
+				this.loadTags = function (query) {
+					return $http.get('/expenses/ngtaglist?text=' + query)
+				}
 			},
 			controllerAs: "expenseCtrl"
 		};

--- a/public/javascripts/AngularApp.js
+++ b/public/javascripts/AngularApp.js
@@ -1,5 +1,5 @@
 (function () {
-	var app = angular.module('expTracker', ['angularMoment', 'tableSort']);
+	var app = angular.module('expTracker', ['angularMoment', 'tableSort','ngTagsInput']);
 	var tracker = {};
 
 	app.controller('TrackerController', ['$http', '$log', function ($http,$log) {

--- a/public/javascripts/AngularApp.js
+++ b/public/javascripts/AngularApp.js
@@ -354,18 +354,20 @@
 			templateUrl: "/templates/expense-form.html",
 			controller: function ($http,$log) {
 				this.expense = {};
-				this.expense.tagsInput = '';
+				this.expense.tags = [];
+				this.expenses.ngTags = [];
 
 				// $log.log(this.today)
 
 				this.addExpense = function (tracker) {
 					this.expense.dateEntered = Date.now();
 					this.expense.amount = Number(this.expense.amount);
-					this.expense.tags = this.expense.tagsInput.split(' ');
-					while(this.expense.tags.indexOf('') >= 0) {
-						// element.tags.splice(element.tags.indexOf(''),1);
-						this.expense.tags.splice(this.expense.tags.indexOf(''),1);
+
+					// convert ngTags into legacy tags
+					for (var i = 0; i < ngTags.length; i++) {
+						this.expense.tags.push(ngTags[i].text);
 					};
+					
 					this.expense.entrySource = 'web-app';
 
 					// send the data to the server

--- a/public/javascripts/ng-tags-input.js
+++ b/public/javascripts/ng-tags-input.js
@@ -1,0 +1,867 @@
+/*!
+ * ngTagsInput v2.1.1
+ * http://mbenford.github.io/ngTagsInput
+ *
+ * Copyright (c) 2013-2014 Michael Benford
+ * License: MIT
+ *
+ * Generated at 2014-09-04 01:27:58 -0300
+ */
+(function() {
+'use strict';
+
+var KEYS = {
+    backspace: 8,
+    tab: 9,
+    enter: 13,
+    escape: 27,
+    space: 32,
+    up: 38,
+    down: 40,
+    comma: 188
+};
+
+var MAX_SAFE_INTEGER = 9007199254740991;
+var SUPPORTED_INPUT_TYPES = ['text', 'email', 'url'];
+
+function SimplePubSub() {
+    var events = {};
+    return {
+        on: function(names, handler) {
+            names.split(' ').forEach(function(name) {
+                if (!events[name]) {
+                    events[name] = [];
+                }
+                events[name].push(handler);
+            });
+            return this;
+        },
+        trigger: function(name, args) {
+            angular.forEach(events[name], function(handler) {
+                handler.call(null, args);
+            });
+            return this;
+        }
+    };
+}
+
+function makeObjectArray(array, key) {
+    array = array || [];
+    if (array.length > 0 && !angular.isObject(array[0])) {
+        array.forEach(function(item, index) {
+            array[index] = {};
+            array[index][key] = item;
+        });
+    }
+    return array;
+}
+
+function findInObjectArray(array, obj, key) {
+    var item = null;
+    for (var i = 0; i < array.length; i++) {
+        // I'm aware of the internationalization issues regarding toLowerCase()
+        // but I couldn't come up with a better solution right now
+        if (safeToString(array[i][key]).toLowerCase() === safeToString(obj[key]).toLowerCase()) {
+            item = array[i];
+            break;
+        }
+    }
+    return item;
+}
+
+function replaceAll(str, substr, newSubstr) {
+    if (!substr) {
+        return str;
+    }
+
+    var expression = substr.replace(/([.?*+^$[\]\\(){}|-])/g, '\\$1');
+    return str.replace(new RegExp(expression, 'gi'), newSubstr);
+}
+
+function safeToString(value) {
+    return angular.isUndefined(value) || value == null ? '' : value.toString().trim();
+}
+
+function encodeHTML(value) {
+    return value.replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;');
+}
+
+var tagsInput = angular.module('ngTagsInput', []);
+
+/**
+ * @ngdoc directive
+ * @name tagsInput
+ * @module ngTagsInput
+ *
+ * @description
+ * Renders an input box with tag editing support.
+ *
+ * @param {string} ngModel Assignable angular expression to data-bind to.
+ * @param {string=} [displayProperty=text] Property to be rendered as the tag label.
+ * @param {string=} [input=text] Type of the input element. Only 'text', 'email' and 'url' are supported values.
+ * @param {number=} tabindex Tab order of the control.
+ * @param {string=} [placeholder=Add a tag] Placeholder text for the control.
+ * @param {number=} [minLength=3] Minimum length for a new tag.
+ * @param {number=} [maxLength=MAX_SAFE_INTEGER] Maximum length allowed for a new tag.
+ * @param {number=} [minTags=0] Sets minTags validation error key if the number of tags added is less than minTags.
+ * @param {number=} [maxTags=MAX_SAFE_INTEGER] Sets maxTags validation error key if the number of tags added is greater than maxTags.
+ * @param {boolean=} [allowLeftoverText=false] Sets leftoverText validation error key if there is any leftover text in
+ *                                             the input element when the directive loses focus.
+ * @param {string=} [removeTagSymbol=×] Symbol character for the remove tag button.
+ * @param {boolean=} [addOnEnter=true] Flag indicating that a new tag will be added on pressing the ENTER key.
+ * @param {boolean=} [addOnSpace=false] Flag indicating that a new tag will be added on pressing the SPACE key.
+ * @param {boolean=} [addOnComma=true] Flag indicating that a new tag will be added on pressing the COMMA key.
+ * @param {boolean=} [addOnBlur=true] Flag indicating that a new tag will be added when the input field loses focus.
+ * @param {boolean=} [replaceSpacesWithDashes=true] Flag indicating that spaces will be replaced with dashes.
+ * @param {string=} [allowedTagsPattern=.+] Regular expression that determines whether a new tag is valid.
+ * @param {boolean=} [enableEditingLastTag=false] Flag indicating that the last tag will be moved back into
+ *                                                the new tag input box instead of being removed when the backspace key
+ *                                                is pressed and the input box is empty.
+ * @param {boolean=} [addFromAutocompleteOnly=false] Flag indicating that only tags coming from the autocomplete list will be allowed.
+ *                                                   When this flag is true, addOnEnter, addOnComma, addOnSpace, addOnBlur and
+ *                                                   allowLeftoverText values are ignored.
+ * @param {expression} onTagAdded Expression to evaluate upon adding a new tag. The new tag is available as $tag.
+ * @param {expression} onTagRemoved Expression to evaluate upon removing an existing tag. The removed tag is available as $tag.
+ */
+tagsInput.directive('tagsInput', ["$timeout","$document","tagsInputConfig", function($timeout, $document, tagsInputConfig) {
+    function TagList(options, events) {
+        var self = {}, getTagText, setTagText, tagIsValid;
+
+        getTagText = function(tag) {
+            return safeToString(tag[options.displayProperty]);
+        };
+
+        setTagText = function(tag, text) {
+            tag[options.displayProperty] = text;
+        };
+
+        tagIsValid = function(tag) {
+            var tagText = getTagText(tag);
+
+            return tagText &&
+                   tagText.length >= options.minLength &&
+                   tagText.length <= options.maxLength &&
+                   options.allowedTagsPattern.test(tagText) &&
+                   !findInObjectArray(self.items, tag, options.displayProperty);
+        };
+
+        self.items = [];
+
+        self.addText = function(text) {
+            var tag = {};
+            setTagText(tag, text);
+            return self.add(tag);
+        };
+
+        self.add = function(tag) {
+            var tagText = getTagText(tag);
+
+            if (options.replaceSpacesWithDashes) {
+                tagText = tagText.replace(/\s/g, '-');
+            }
+
+            setTagText(tag, tagText);
+
+            if (tagIsValid(tag)) {
+                self.items.push(tag);
+                events.trigger('tag-added', { $tag: tag });
+            }
+            else if (tagText) {
+                events.trigger('invalid-tag', { $tag: tag });
+            }
+
+            return tag;
+        };
+
+        self.remove = function(index) {
+            var tag = self.items.splice(index, 1)[0];
+            events.trigger('tag-removed', { $tag: tag });
+            return tag;
+        };
+
+        self.removeLast = function() {
+            var tag, lastTagIndex = self.items.length - 1;
+
+            if (options.enableEditingLastTag || self.selected) {
+                self.selected = null;
+                tag = self.remove(lastTagIndex);
+            }
+            else if (!self.selected) {
+                self.selected = self.items[lastTagIndex];
+            }
+
+            return tag;
+        };
+
+        return self;
+    }
+
+    function validateType(type) {
+        return SUPPORTED_INPUT_TYPES.indexOf(type) !== -1;
+    }
+
+    return {
+        restrict: 'E',
+        require: 'ngModel',
+        scope: {
+            tags: '=ngModel',
+            onTagAdded: '&',
+            onTagRemoved: '&'
+        },
+        replace: false,
+        transclude: true,
+        templateUrl: 'ngTagsInput/tags-input.html',
+        controller: ["$scope","$attrs","$element", function($scope, $attrs, $element) {
+            $scope.events = new SimplePubSub();
+
+            tagsInputConfig.load('tagsInput', $scope, $attrs, {
+                type: [String, 'text', validateType],
+                placeholder: [String, 'Add a tag'],
+                tabindex: [Number, null],
+                removeTagSymbol: [String, String.fromCharCode(215)],
+                replaceSpacesWithDashes: [Boolean, true],
+                minLength: [Number, 3],
+                maxLength: [Number, MAX_SAFE_INTEGER],
+                addOnEnter: [Boolean, true],
+                addOnSpace: [Boolean, false],
+                addOnComma: [Boolean, true],
+                addOnBlur: [Boolean, true],
+                allowedTagsPattern: [RegExp, /.+/],
+                enableEditingLastTag: [Boolean, false],
+                minTags: [Number, 0],
+                maxTags: [Number, MAX_SAFE_INTEGER],
+                displayProperty: [String, 'text'],
+                allowLeftoverText: [Boolean, false],
+                addFromAutocompleteOnly: [Boolean, false]
+            });
+
+            $scope.tagList = new TagList($scope.options, $scope.events);
+
+            this.registerAutocomplete = function() {
+                var input = $element.find('input');
+                input.on('keydown', function(e) {
+                    $scope.events.trigger('input-keydown', e);
+                });
+
+                return {
+                    addTag: function(tag) {
+                        return $scope.tagList.add(tag);
+                    },
+                    focusInput: function() {
+                        input[0].focus();
+                    },
+                    getTags: function() {
+                        return $scope.tags;
+                    },
+                    getCurrentTagText: function() {
+                        return $scope.newTag.text;
+                    },
+                    getOptions: function() {
+                        return $scope.options;
+                    },
+                    on: function(name, handler) {
+                        $scope.events.on(name, handler);
+                        return this;
+                    }
+                };
+            };
+        }],
+        link: function(scope, element, attrs, ngModelCtrl) {
+            var hotkeys = [KEYS.enter, KEYS.comma, KEYS.space, KEYS.backspace],
+                tagList = scope.tagList,
+                events = scope.events,
+                options = scope.options,
+                input = element.find('input'),
+                validationOptions = ['minTags', 'maxTags', 'allowLeftoverText'],
+                setElementValidity;
+
+            setElementValidity = function() {
+                ngModelCtrl.$setValidity('maxTags', scope.tags.length <= options.maxTags);
+                ngModelCtrl.$setValidity('minTags', scope.tags.length >= options.minTags);
+                ngModelCtrl.$setValidity('leftoverText', options.allowLeftoverText ? true : !scope.newTag.text);
+            };
+
+            events
+                .on('tag-added', scope.onTagAdded)
+                .on('tag-removed', scope.onTagRemoved)
+                .on('tag-added', function() {
+                    scope.newTag.text = '';
+                })
+                .on('tag-added tag-removed', function() {
+                    ngModelCtrl.$setViewValue(scope.tags);
+                })
+                .on('invalid-tag', function() {
+                    scope.newTag.invalid = true;
+                })
+                .on('input-change', function() {
+                    tagList.selected = null;
+                    scope.newTag.invalid = null;
+                })
+                .on('input-focus', function() {
+                    ngModelCtrl.$setValidity('leftoverText', true);
+                })
+                .on('input-blur', function() {
+                    if (!options.addFromAutocompleteOnly) {
+                        if (options.addOnBlur) {
+                            tagList.addText(scope.newTag.text);
+                        }
+
+                        setElementValidity();
+                    }
+                })
+                .on('option-change', function(e) {
+                    if (validationOptions.indexOf(e.name) !== -1) {
+                        setElementValidity();
+                    }
+                });
+
+            scope.newTag = { text: '', invalid: null };
+
+            scope.getDisplayText = function(tag) {
+                return safeToString(tag[options.displayProperty]);
+            };
+
+            scope.track = function(tag) {
+                return tag[options.displayProperty];
+            };
+
+            scope.newTagChange = function() {
+                events.trigger('input-change', scope.newTag.text);
+            };
+
+            scope.$watch('tags', function(value) {
+                scope.tags = makeObjectArray(value, options.displayProperty);
+                tagList.items = scope.tags;
+            });
+
+            scope.$watch('tags.length', function() {
+                setElementValidity();
+            });
+
+            input
+                .on('keydown', function(e) {
+                    // This hack is needed because jqLite doesn't implement stopImmediatePropagation properly.
+                    // I've sent a PR to Angular addressing this issue and hopefully it'll be fixed soon.
+                    // https://github.com/angular/angular.js/pull/4833
+                    if (e.isImmediatePropagationStopped && e.isImmediatePropagationStopped()) {
+                        return;
+                    }
+
+                    var key = e.keyCode,
+                        isModifier = e.shiftKey || e.altKey || e.ctrlKey || e.metaKey,
+                        addKeys = {},
+                        shouldAdd, shouldRemove;
+
+                    if (isModifier || hotkeys.indexOf(key) === -1) {
+                        return;
+                    }
+
+                    addKeys[KEYS.enter] = options.addOnEnter;
+                    addKeys[KEYS.comma] = options.addOnComma;
+                    addKeys[KEYS.space] = options.addOnSpace;
+
+                    shouldAdd = !options.addFromAutocompleteOnly && addKeys[key];
+                    shouldRemove = !shouldAdd && key === KEYS.backspace && scope.newTag.text.length === 0;
+
+                    if (shouldAdd) {
+                        tagList.addText(scope.newTag.text);
+
+                        scope.$apply();
+                        e.preventDefault();
+                    }
+                    else if (shouldRemove) {
+                        var tag = tagList.removeLast();
+                        if (tag && options.enableEditingLastTag) {
+                            scope.newTag.text = tag[options.displayProperty];
+                        }
+
+                        scope.$apply();
+                        e.preventDefault();
+                    }
+                })
+                .on('focus', function() {
+                    if (scope.hasFocus) {
+                        return;
+                    }
+
+                    scope.hasFocus = true;
+                    events.trigger('input-focus');
+
+                    scope.$apply();
+                })
+                .on('blur', function() {
+                    $timeout(function() {
+                        var activeElement = $document.prop('activeElement'),
+                            lostFocusToBrowserWindow = activeElement === input[0],
+                            lostFocusToChildElement = element[0].contains(activeElement);
+
+                        if (lostFocusToBrowserWindow || !lostFocusToChildElement) {
+                            scope.hasFocus = false;
+                            events.trigger('input-blur');
+                        }
+                    });
+                });
+
+            element.find('div').on('click', function() {
+                input[0].focus();
+            });
+        }
+    };
+}]);
+
+/**
+ * @ngdoc directive
+ * @name autoComplete
+ * @module ngTagsInput
+ *
+ * @description
+ * Provides autocomplete support for the tagsInput directive.
+ *
+ * @param {expression} source Expression to evaluate upon changing the input content. The input value is available as
+ *                            $query. The result of the expression must be a promise that eventually resolves to an
+ *                            array of strings.
+ * @param {number=} [debounceDelay=100] Amount of time, in milliseconds, to wait before evaluating the expression in
+ *                                      the source option after the last keystroke.
+ * @param {number=} [minLength=3] Minimum number of characters that must be entered before evaluating the expression
+ *                                 in the source option.
+ * @param {boolean=} [highlightMatchedText=true] Flag indicating that the matched text will be highlighted in the
+ *                                               suggestions list.
+ * @param {number=} [maxResultsToShow=10] Maximum number of results to be displayed at a time.
+ * @param {boolean=} [loadOnDownArrow=false] Flag indicating that the source option will be evaluated when the down arrow
+ *                                           key is pressed and the suggestion list is closed. The current input value
+ *                                           is available as $query.
+ * @param {boolean=} {loadOnEmpty=false} Flag indicating that the source option will be evaluated when the input content
+ *                                       becomes empty. The $query variable will be passed to the expression as an empty string.
+ * @param {boolean=} {loadOnFocus=false} Flag indicating that the source option will be evaluated when the input element
+ *                                       gains focus. The current input value is available as $query.
+ */
+tagsInput.directive('autoComplete', ["$document","$timeout","$sce","tagsInputConfig", function($document, $timeout, $sce, tagsInputConfig) {
+    function SuggestionList(loadFn, options) {
+        var self = {}, debouncedLoadId, getDifference, lastPromise;
+
+        getDifference = function(array1, array2) {
+            return array1.filter(function(item) {
+                return !findInObjectArray(array2, item, options.tagsInput.displayProperty);
+            });
+        };
+
+        self.reset = function() {
+            lastPromise = null;
+
+            self.items = [];
+            self.visible = false;
+            self.index = -1;
+            self.selected = null;
+            self.query = null;
+
+            $timeout.cancel(debouncedLoadId);
+        };
+        self.show = function() {
+            self.selected = null;
+            self.visible = true;
+        };
+        self.load = function(query, tags) {
+            $timeout.cancel(debouncedLoadId);
+            debouncedLoadId = $timeout(function() {
+                self.query = query;
+
+                var promise = loadFn({ $query: query });
+                lastPromise = promise;
+
+                promise.then(function(items) {
+                    if (promise !== lastPromise) {
+                        return;
+                    }
+
+                    items = makeObjectArray(items.data || items, options.tagsInput.displayProperty);
+                    items = getDifference(items, tags);
+                    self.items = items.slice(0, options.maxResultsToShow);
+
+                    if (self.items.length > 0) {
+                        self.show();
+                    }
+                    else {
+                        self.reset();
+                    }
+                });
+            }, options.debounceDelay, false);
+        };
+        self.selectNext = function() {
+            self.select(++self.index);
+        };
+        self.selectPrior = function() {
+            self.select(--self.index);
+        };
+        self.select = function(index) {
+            if (index < 0) {
+                index = self.items.length - 1;
+            }
+            else if (index >= self.items.length) {
+                index = 0;
+            }
+            self.index = index;
+            self.selected = self.items[index];
+        };
+
+        self.reset();
+
+        return self;
+    }
+
+    return {
+        restrict: 'E',
+        require: '^tagsInput',
+        scope: { source: '&' },
+        templateUrl: 'ngTagsInput/auto-complete.html',
+        link: function(scope, element, attrs, tagsInputCtrl) {
+            var hotkeys = [KEYS.enter, KEYS.tab, KEYS.escape, KEYS.up, KEYS.down],
+                suggestionList, tagsInput, options, getItem, getDisplayText, shouldLoadSuggestions;
+
+            tagsInputConfig.load('autoComplete', scope, attrs, {
+                debounceDelay: [Number, 100],
+                minLength: [Number, 3],
+                highlightMatchedText: [Boolean, true],
+                maxResultsToShow: [Number, 10],
+                loadOnDownArrow: [Boolean, false],
+                loadOnEmpty: [Boolean, false],
+                loadOnFocus: [Boolean, false]
+            });
+
+            options = scope.options;
+
+            tagsInput = tagsInputCtrl.registerAutocomplete();
+            options.tagsInput = tagsInput.getOptions();
+
+            suggestionList = new SuggestionList(scope.source, options);
+
+            getItem = function(item) {
+                return item[options.tagsInput.displayProperty];
+            };
+
+            getDisplayText = function(item) {
+                return safeToString(getItem(item));
+            };
+
+            shouldLoadSuggestions = function(value) {
+                return value && value.length >= options.minLength || !value && options.loadOnEmpty;
+            };
+
+            scope.suggestionList = suggestionList;
+
+            scope.addSuggestionByIndex = function(index) {
+                suggestionList.select(index);
+                scope.addSuggestion();
+            };
+
+            scope.addSuggestion = function() {
+                var added = false;
+
+                if (suggestionList.selected) {
+                    tagsInput.addTag(suggestionList.selected);
+                    suggestionList.reset();
+                    tagsInput.focusInput();
+
+                    added = true;
+                }
+                return added;
+            };
+
+            scope.highlight = function(item) {
+                var text = getDisplayText(item);
+                text = encodeHTML(text);
+                if (options.highlightMatchedText) {
+                    text = replaceAll(text, encodeHTML(suggestionList.query), '<em>$&</em>');
+                }
+                return $sce.trustAsHtml(text);
+            };
+
+            scope.track = function(item) {
+                return getItem(item);
+            };
+
+            tagsInput
+                .on('tag-added tag-removed invalid-tag input-blur', function() {
+                    suggestionList.reset();
+                })
+                .on('input-change', function(value) {
+                    if (shouldLoadSuggestions(value)) {
+                        suggestionList.load(value, tagsInput.getTags());
+                    }
+                    else {
+                        suggestionList.reset();
+                    }
+                })
+                .on('input-focus', function() {
+                    var value = tagsInput.getCurrentTagText();
+                    if (options.loadOnFocus && shouldLoadSuggestions(value)) {
+                        suggestionList.load(value, tagsInput.getTags());
+                    }
+                })
+                .on('input-keydown', function(e) {
+                    // This hack is needed because jqLite doesn't implement stopImmediatePropagation properly.
+                    // I've sent a PR to Angular addressing this issue and hopefully it'll be fixed soon.
+                    // https://github.com/angular/angular.js/pull/4833
+                    var immediatePropagationStopped = false;
+                    e.stopImmediatePropagation = function() {
+                        immediatePropagationStopped = true;
+                        e.stopPropagation();
+                    };
+                    e.isImmediatePropagationStopped = function() {
+                        return immediatePropagationStopped;
+                    };
+
+                    var key = e.keyCode,
+                        handled = false;
+
+                    if (hotkeys.indexOf(key) === -1) {
+                        return;
+                    }
+
+                    if (suggestionList.visible) {
+
+                        if (key === KEYS.down) {
+                            suggestionList.selectNext();
+                            handled = true;
+                        }
+                        else if (key === KEYS.up) {
+                            suggestionList.selectPrior();
+                            handled = true;
+                        }
+                        else if (key === KEYS.escape) {
+                            suggestionList.reset();
+                            handled = true;
+                        }
+                        else if (key === KEYS.enter || key === KEYS.tab) {
+                            handled = scope.addSuggestion();
+                        }
+                    }
+                    else {
+                        if (key === KEYS.down && scope.options.loadOnDownArrow) {
+                            suggestionList.load(tagsInput.getCurrentTagText(), tagsInput.getTags());
+                            handled = true;
+                        }
+                    }
+
+                    if (handled) {
+                        e.preventDefault();
+                        e.stopImmediatePropagation();
+                        scope.$apply();
+                    }
+                });
+        }
+    };
+}]);
+
+
+/**
+ * @ngdoc directive
+ * @name tiTranscludeAppend
+ * @module ngTagsInput
+ *
+ * @description
+ * Re-creates the old behavior of ng-transclude. Used internally by tagsInput directive.
+ */
+tagsInput.directive('tiTranscludeAppend', function() {
+    return function(scope, element, attrs, ctrl, transcludeFn) {
+        transcludeFn(function(clone) {
+            element.append(clone);
+        });
+    };
+});
+
+/**
+ * @ngdoc directive
+ * @name tiAutosize
+ * @module ngTagsInput
+ *
+ * @description
+ * Automatically sets the input's width so its content is always visible. Used internally by tagsInput directive.
+ */
+tagsInput.directive('tiAutosize', ["tagsInputConfig", function(tagsInputConfig) {
+    return {
+        restrict: 'A',
+        require: 'ngModel',
+        link: function(scope, element, attrs, ctrl) {
+            var threshold = tagsInputConfig.getTextAutosizeThreshold(),
+                span, resize;
+
+            span = angular.element('<span class="input"></span>');
+            span.css('display', 'none')
+                .css('visibility', 'hidden')
+                .css('width', 'auto')
+                .css('white-space', 'pre');
+
+            element.parent().append(span);
+
+            resize = function(originalValue) {
+                var value = originalValue, width;
+
+                if (angular.isString(value) && value.length === 0) {
+                    value = attrs.placeholder;
+                }
+
+                if (value) {
+                    span.text(value);
+                    span.css('display', '');
+                    width = span.prop('offsetWidth');
+                    span.css('display', 'none');
+                }
+
+                element.css('width', width ? width + threshold + 'px' : '');
+
+                return originalValue;
+            };
+
+            ctrl.$parsers.unshift(resize);
+            ctrl.$formatters.unshift(resize);
+
+            attrs.$observe('placeholder', function(value) {
+                if (!ctrl.$modelValue) {
+                    resize(value);
+                }
+            });
+        }
+    };
+}]);
+
+/**
+ * @ngdoc directive
+ * @name tiBindAttrs
+ * @module ngTagsInput
+ *
+ * @description
+ * Binds attributes to expressions. Used internally by tagsInput directive.
+ */
+tagsInput.directive('tiBindAttrs', function() {
+    return function(scope, element, attrs) {
+        scope.$watch(attrs.tiBindAttrs, function(value) {
+            angular.forEach(value, function(value, key) {
+                attrs.$set(key, value);
+            });
+        }, true);
+    };
+});
+
+/**
+ * @ngdoc service
+ * @name tagsInputConfig
+ * @module ngTagsInput
+ *
+ * @description
+ * Sets global configuration settings for both tagsInput and autoComplete directives. It's also used internally to parse and
+ * initialize options from HTML attributes.
+ */
+tagsInput.provider('tagsInputConfig', function() {
+    var globalDefaults = {},
+        interpolationStatus = {},
+        autosizeThreshold = 3;
+
+    /**
+     * @ngdoc method
+     * @name setDefaults
+     * @description Sets the default configuration option for a directive.
+     * @methodOf tagsInputConfig
+     *
+     * @param {string} directive Name of the directive to be configured. Must be either 'tagsInput' or 'autoComplete'.
+     * @param {object} defaults Object containing options and their values.
+     *
+     * @returns {object} The service itself for chaining purposes.
+     */
+    this.setDefaults = function(directive, defaults) {
+        globalDefaults[directive] = defaults;
+        return this;
+    };
+
+    /***
+     * @ngdoc method
+     * @name setActiveInterpolation
+     * @description Sets active interpolation for a set of options.
+     * @methodOf tagsInputConfig
+     *
+     * @param {string} directive Name of the directive to be configured. Must be either 'tagsInput' or 'autoComplete'.
+     * @param {object} options Object containing which options should have interpolation turned on at all times.
+     *
+     * @returns {object} The service itself for chaining purposes.
+     */
+    this.setActiveInterpolation = function(directive, options) {
+        interpolationStatus[directive] = options;
+        return this;
+    };
+
+    /***
+     * @ngdoc method
+     * @name setTextAutosizeThreshold
+     * @methodOf tagsInputConfig
+     *
+     * @param {number} threshold Threshold to be used by the tagsInput directive to re-size the input element based on its contents.
+     *
+     * @returns {object} The service itself for chaining purposes.
+     */
+    this.setTextAutosizeThreshold = function(threshold) {
+        autosizeThreshold = threshold;
+        return this;
+    };
+
+    this.$get = ["$interpolate", function($interpolate) {
+        var converters = {};
+        converters[String] = function(value) { return value; };
+        converters[Number] = function(value) { return parseInt(value, 10); };
+        converters[Boolean] = function(value) { return value.toLowerCase() === 'true'; };
+        converters[RegExp] = function(value) { return new RegExp(value); };
+
+        return {
+            load: function(directive, scope, attrs, options) {
+                var defaultValidator = function() { return true; };
+
+                scope.options = {};
+
+                angular.forEach(options, function(value, key) {
+                    var type, localDefault, validator, converter, getDefault, updateValue;
+
+                    type = value[0];
+                    localDefault = value[1];
+                    validator = value[2] || defaultValidator;
+                    converter = converters[type];
+
+                    getDefault = function() {
+                        var globalValue = globalDefaults[directive] && globalDefaults[directive][key];
+                        return angular.isDefined(globalValue) ? globalValue : localDefault;
+                    };
+
+                    updateValue = function(value) {
+                        scope.options[key] = value && validator(value) ? converter(value) : getDefault();
+                    };
+
+                    if (interpolationStatus[directive] && interpolationStatus[directive][key]) {
+                        attrs.$observe(key, function(value) {
+                            updateValue(value);
+                            scope.events.trigger('option-change', { name: key, newValue: value });
+                        });
+                    }
+                    else {
+                        updateValue(attrs[key] && $interpolate(attrs[key])(scope.$parent));
+                    }
+                });
+            },
+            getTextAutosizeThreshold: function() {
+                return autosizeThreshold;
+            }
+        };
+    }];
+});
+
+
+/* HTML templates */
+tagsInput.run(["$templateCache", function($templateCache) {
+    $templateCache.put('ngTagsInput/tags-input.html',
+    "<div class=\"host\" tabindex=\"-1\" ti-transclude-append=\"\"><div class=\"tags\" ng-class=\"{focused: hasFocus}\"><ul class=\"tag-list\"><li class=\"tag-item\" ng-repeat=\"tag in tagList.items track by track(tag)\" ng-class=\"{ selected: tag == tagList.selected }\"><span ng-bind=\"getDisplayText(tag)\"></span> <a class=\"remove-button\" ng-click=\"tagList.remove($index)\" ng-bind=\"options.removeTagSymbol\"></a></li></ul><input class=\"input\" ng-model=\"newTag.text\" ng-change=\"newTagChange()\" ng-trim=\"false\" ng-class=\"{'invalid-tag': newTag.invalid}\" ti-bind-attrs=\"{type: options.type, placeholder: options.placeholder, tabindex: options.tabindex}\" ti-autosize=\"\"></div></div>"
+  );
+
+  $templateCache.put('ngTagsInput/auto-complete.html',
+    "<div class=\"autocomplete\" ng-show=\"suggestionList.visible\"><ul class=\"suggestion-list\"><li class=\"suggestion-item\" ng-repeat=\"item in suggestionList.items track by track(item)\" ng-class=\"{selected: item == suggestionList.selected}\" ng-click=\"addSuggestionByIndex($index)\" ng-mouseenter=\"suggestionList.select($index)\" ng-bind-html=\"highlight(item)\"></li></ul></div>"
+  );
+}]);
+
+}());

--- a/public/stylesheets/ng-tags-input.bootstrap.css
+++ b/public/stylesheets/ng-tags-input.bootstrap.css
@@ -1,0 +1,166 @@
+tags-input {
+  box-shadow: none;
+  border: none;
+  padding: 0;
+  min-height: 34px;
+}
+tags-input .host {
+  margin: 0;
+}
+tags-input .tags {
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  border: 1px solid #cccccc;
+  border-radius: 4px;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  -webkit-transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
+  -moz-transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
+  transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
+}
+tags-input .tags .tag-item {
+  color: white;
+  background: #428bca;
+  border: 1px solid #357ebd;
+  border-radius: 4px;
+}
+tags-input .tags .tag-item.selected {
+  color: white;
+  background: #d9534f;
+  border: 1px solid #d43f3a;
+}
+tags-input .tags .tag-item .remove-button:hover {
+  text-decoration: none;
+}
+tags-input .tags.focused {
+  border: 1px solid #66afe9;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
+  -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
+}
+tags-input .autocomplete {
+  border-radius: 4px;
+}
+tags-input .autocomplete .suggestion-item.selected {
+  color: #262626;
+  background-color: whitesmoke;
+}
+tags-input .autocomplete .suggestion-item.selected em {
+  color: #262626;
+  background-color: whitesmoke;
+}
+tags-input .autocomplete .suggestion-item em {
+  color: black;
+  background-color: white;
+}
+tags-input.ng-invalid .tags {
+  border-color: #843534;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ce8483;
+  -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ce8483;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ce8483;
+}
+
+.input-group tags-input {
+  padding: 0;
+  display: table-cell;
+}
+.input-group tags-input:not(:first-child) .tags {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+.input-group tags-input:not(:last-child) .tags {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.input-group-lg tags-input:first-child .tags {
+  border-top-left-radius: 6px;
+  border-bottom-left-radius: 6px;
+}
+.input-group-lg tags-input:last-child .tags {
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
+}
+
+.input-group-sm tags-input:first-child .tags {
+  border-top-left-radius: 3px;
+  border-bottom-left-radius: 3px;
+}
+.input-group-sm tags-input:last-child .tags {
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
+}
+
+tags-input.ti-input-lg, .input-group-lg tags-input {
+  min-height: 46px;
+}
+tags-input.ti-input-lg .tags, .input-group-lg tags-input .tags {
+  border-radius: 6px;
+}
+tags-input.ti-input-lg .tags .tag-item, .input-group-lg tags-input .tags .tag-item {
+  height: 38px;
+  line-height: 37px;
+  font-size: 18px;
+  border-radius: 6px;
+}
+tags-input.ti-input-lg .tags .tag-item .remove-button, .input-group-lg tags-input .tags .tag-item .remove-button {
+  font-size: 20px;
+}
+tags-input.ti-input-lg .tags .input, .input-group-lg tags-input .tags .input {
+  height: 38px;
+  font-size: 18px;
+}
+tags-input.ti-input-sm, .input-group-sm tags-input {
+  min-height: 30px;
+}
+tags-input.ti-input-sm .tags, .input-group-sm tags-input .tags {
+  border-radius: 3px;
+}
+tags-input.ti-input-sm .tags .tag-item, .input-group-sm tags-input .tags .tag-item {
+  height: 22px;
+  line-height: 21px;
+  font-size: 12px;
+  border-radius: 3px;
+}
+tags-input.ti-input-sm .tags .tag-item .remove-button, .input-group-sm tags-input .tags .tag-item .remove-button {
+  font-size: 16px;
+}
+tags-input.ti-input-sm .tags .input, .input-group-sm tags-input .tags .input {
+  height: 22px;
+  font-size: 12px;
+}
+
+.has-feedback tags-input .tags {
+  padding-right: 30px;
+}
+
+.has-success tags-input .tags {
+  border-color: #3c763d;
+}
+.has-success tags-input .tags.focused {
+  border-color: #2b542c;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #67b168;
+  -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #67b168;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #67b168;
+}
+
+.has-error tags-input .tags {
+  border-color: #a94442;
+}
+.has-error tags-input .tags.focused {
+  border-color: #843534;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ce8483;
+  -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ce8483;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ce8483;
+}
+
+.has-warning tags-input .tags {
+  border-color: #8a6d3b;
+}
+.has-warning tags-input .tags.focused {
+  border-color: #66512c;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #c0a16b;
+  -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #c0a16b;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #c0a16b;
+}

--- a/public/stylesheets/ng-tags-input.bootstrap.css
+++ b/public/stylesheets/ng-tags-input.bootstrap.css
@@ -43,12 +43,12 @@ tags-input .autocomplete {
   border-radius: 4px;
 }
 tags-input .autocomplete .suggestion-item.selected {
-  color: #262626;
-  background-color: whitesmoke;
+  color: white;
+  background-color: #0097cf;
 }
 tags-input .autocomplete .suggestion-item.selected em {
-  color: #262626;
-  background-color: whitesmoke;
+  color: white;
+  background-color: #0097cf;
 }
 tags-input .autocomplete .suggestion-item em {
   color: black;

--- a/public/stylesheets/ng-tags-input.css
+++ b/public/stylesheets/ng-tags-input.css
@@ -1,0 +1,133 @@
+tags-input {
+  display: block;
+}
+tags-input *, tags-input *:before, tags-input *:after {
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+}
+tags-input .host {
+  position: relative;
+  margin-top: 5px;
+  margin-bottom: 5px;
+  height: 100%;
+}
+tags-input .host:active {
+  outline: none;
+}
+
+tags-input .tags {
+  -moz-appearance: textfield;
+  -webkit-appearance: textfield;
+  padding: 1px;
+  overflow: hidden;
+  word-wrap: break-word;
+  cursor: text;
+  background-color: white;
+  border: 1px solid darkgray;
+  box-shadow: 1px 1px 1px 0 lightgray inset;
+  height: 100%;
+}
+tags-input .tags.focused {
+  outline: none;
+  -webkit-box-shadow: 0 0 3px 1px rgba(5, 139, 242, 0.6);
+  -moz-box-shadow: 0 0 3px 1px rgba(5, 139, 242, 0.6);
+  box-shadow: 0 0 3px 1px rgba(5, 139, 242, 0.6);
+}
+tags-input .tags .tag-list {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+}
+tags-input .tags .tag-item {
+  margin: 2px;
+  padding: 0 5px;
+  display: inline-block;
+  float: left;
+  font: 14px "Helvetica Neue", Helvetica, Arial, sans-serif;
+  height: 26px;
+  line-height: 25px;
+  border: 1px solid #acacac;
+  border-radius: 3px;
+  background: -webkit-linear-gradient(top, #f0f9ff 0%, #cbebff 47%, #a1dbff 100%);
+  background: linear-gradient(to bottom, #f0f9ff 0%, #cbebff 47%, #a1dbff 100%);
+}
+tags-input .tags .tag-item.selected {
+  background: -webkit-linear-gradient(top, #febbbb 0%, #fe9090 45%, #ff5c5c 100%);
+  background: linear-gradient(to bottom, #febbbb 0%, #fe9090 45%, #ff5c5c 100%);
+}
+tags-input .tags .tag-item .remove-button {
+  margin: 0 0 0 5px;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  vertical-align: middle;
+  font: bold 16px Arial, sans-serif;
+  color: #585858;
+}
+tags-input .tags .tag-item .remove-button:active {
+  color: red;
+}
+tags-input .tags .input {
+  border: 0;
+  outline: none;
+  margin: 2px;
+  padding: 0;
+  padding-left: 5px;
+  float: left;
+  height: 26px;
+  font: 14px "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+tags-input .tags .input.invalid-tag {
+  color: red;
+}
+tags-input .tags .input::-ms-clear {
+  display: none;
+}
+tags-input.ng-invalid .tags {
+  -webkit-box-shadow: 0 0 3px 1px rgba(255, 0, 0, 0.6);
+  -moz-box-shadow: 0 0 3px 1px rgba(255, 0, 0, 0.6);
+  box-shadow: 0 0 3px 1px rgba(255, 0, 0, 0.6);
+}
+
+tags-input .autocomplete {
+  margin-top: 5px;
+  position: absolute;
+  padding: 5px 0;
+  z-index: 999;
+  width: 100%;
+  background-color: white;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  -webkit-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+  -moz-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+}
+tags-input .autocomplete .suggestion-list {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+}
+tags-input .autocomplete .suggestion-item {
+  padding: 5px 10px;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font: 16px "Helvetica Neue", Helvetica, Arial, sans-serif;
+  color: black;
+  background-color: white;
+}
+tags-input .autocomplete .suggestion-item.selected {
+  color: white;
+  background-color: #0097cf;
+}
+tags-input .autocomplete .suggestion-item.selected em {
+  color: white;
+  background-color: #0097cf;
+}
+tags-input .autocomplete .suggestion-item em {
+  font: normal bold 16px "Helvetica Neue", Helvetica, Arial, sans-serif;
+  color: black;
+  background-color: white;
+}

--- a/public/templates/expense-detail.html
+++ b/public/templates/expense-detail.html
@@ -86,7 +86,9 @@
 					<div class="form-group">
 						<label for="editTags" class="col-sm-2 control-label">Tags</label>
 						<div class="col-sm-6">
-							<tags-input ng-model="expDetCtrl.expense.ngTags"></tags-input>
+							<tags-input ng-model="expDetCtrl.expense.ngTags">
+								<auto-complete source="expDetCtrl.loadTags($query)"></auto-complete>
+							</tags-input>
 						</div>
 						<label for="editAmount" class="col-sm-2 control-label">Amount</label>
 						<div class="col-sm-2">

--- a/public/templates/expense-detail.html
+++ b/public/templates/expense-detail.html
@@ -86,7 +86,7 @@
 					<div class="form-group">
 						<label for="editTags" class="col-sm-2 control-label">Tags</label>
 						<div class="col-sm-6">
-							<input type="text" class="form-control" id="editTags" ng-model="expDetCtrl.expense.tagsInput">
+							<tags-input ng-model="expDetCtrl.expense.ngTags"></tags-input>
 						</div>
 						<label for="editAmount" class="col-sm-2 control-label">Amount</label>
 						<div class="col-sm-2">

--- a/public/templates/expense-form.html
+++ b/public/templates/expense-form.html
@@ -27,7 +27,9 @@
 			</select>
 		</fieldset>
 		<fieldset class="form-group">
-			<tags-input ng-model="expenseCtrl.expense.ngTags"></tags-input>
+			<tags-input ng-model="expenseCtrl.expense.ngTags">
+				<auto-complete source="expenseCtrl.loadTags($query)"></auto-complete>
+			</tags-input>
 		</fieldset>
 		<fieldset class="form-group"> 					
 			<textarea ng-model="expenseCtrl.expense.memo" class="form-control" placeholder="Expense Memo Area..." title="Memo">

--- a/public/templates/expense-form.html
+++ b/public/templates/expense-form.html
@@ -27,7 +27,7 @@
 			</select>
 		</fieldset>
 		<fieldset class="form-group">
-			<input ng-model="expenseCtrl.expense.tagsInput" class="form-control" placeholder="Tags - Seperated by Spaces" title="Tags" />
+			<tags-input ng-model="expenseCtrl.expense.ngTags"></tags-input>
 		</fieldset>
 		<fieldset class="form-group"> 					
 			<textarea ng-model="expenseCtrl.expense.memo" class="form-control" placeholder="Expense Memo Area..." title="Memo">

--- a/public/templates/monthly-expense-detail.html
+++ b/public/templates/monthly-expense-detail.html
@@ -91,7 +91,9 @@
 						<label for="editTags" class="col-sm-2 control-label">Tags</label>
 						<div class="col-sm-6">
 							<!-- <input type="text" class="form-control" id="editTags" ng-model="monthlyExp.detailExpense.tagsInput"> -->
-							<tags-input ng-model="monthlyExp.detailExpense.ngTags"></tags-input>
+							<tags-input ng-model="monthlyExp.detailExpense.ngTags">
+								<auto-complete source="monthlyExp.loadTags($query)"></auto-complete>
+							</tags-input>
 						</div>
 						<label for="editAmount" class="col-sm-2 control-label">Amount</label>
 						<div class="col-sm-2">

--- a/public/templates/monthly-expense-detail.html
+++ b/public/templates/monthly-expense-detail.html
@@ -90,7 +90,8 @@
 					<div class="form-group">
 						<label for="editTags" class="col-sm-2 control-label">Tags</label>
 						<div class="col-sm-6">
-							<input type="text" class="form-control" id="editTags" ng-model="monthlyExp.detailExpense.tagsInput">
+							<!-- <input type="text" class="form-control" id="editTags" ng-model="monthlyExp.detailExpense.tagsInput"> -->
+							<tags-input ng-model="monthlyExp.detailExpense.ngTags"></tags-input>
 						</div>
 						<label for="editAmount" class="col-sm-2 control-label">Amount</label>
 						<div class="col-sm-2">

--- a/routes/index.js
+++ b/routes/index.js
@@ -102,6 +102,59 @@ router.get('/expenses/taglist', function (req, res, next) {
 	});
 });
 
+/* GET request to /expenses/ngtaglist */
+/* Generates a list of ngTag objects on server side and accepts a query string */
+/* That has the user input - used for autocomplete of ngTags */
+router.get('/expenses/ngtaglist', function (req, res, next) {
+	var ngTagList = []
+	  , ngTag = {}
+	  , taglist = []
+	  , textEntered = req.query.text
+
+	// recursive function to add to ngTagList array
+	function makeNgTagList (legacyTagList) {
+		if (!legacyTagList.length) { return res.json(ngTagList) };
+		var legacyTag = legacyTagList.pop()
+
+		if (legacyTag.search(textEntered) >= 0) {
+			ngTagList.push( { text : legacyTag } )
+		};
+		makeNgTagList(legacyTagList)
+	}
+
+
+	// Copied code from GET at /expenses/taglist
+
+	Expense.find(function (err, expenses) {
+		if (err) { return next(err); };
+
+		expenses.forEach(function (element, index, array) {
+			element.tags.forEach(function (element, index, array) {
+				if (taglist.indexOf(element) < 0 && element != '') {
+					taglist.push(element);
+				};
+			});
+		});
+		
+		taglist.sort()
+		taglist.reverse()
+
+		// end of copied code section
+
+		// want a smart autocomplete list to pull up relevant tags
+		makeNgTagList(taglist)
+
+		// async causing problems... need to use recursion
+		/*taglist.forEach(function (element, index, array) {
+			if (element.search(textEntered) >= 0) {
+				ngTag.text = element;
+				ngTagList.push(ngTag);
+			};
+		});*/
+
+		// res.json(ngTagList);
+	});
+});
 
 /* GET for a single expense at /expenses/:expense */
 router.get('/expenses/:expense', function (req, res) {

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -5,10 +5,13 @@
     <link rel='stylesheet' href='/stylesheets/style.css' />
     <!-- Latest compiled and minified CSS -->
 	<link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css">
+	<link rel="stylesheet" type="text/css" href="/stylesheets/ng-tags-input.css">
+	<link rel="stylesheet" type="text/css" href="/stylesheets/ng-tags-input.bootstrap.css">
 	<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.10/angular.min.js"></script>
 	<script type="text/javascript" src="/javascripts/AngularApp.js"></script>
 	<script type="text/javascript" src="/javascripts/moment.js"></script>
 	<script type="text/javascript" src="/javascripts/angular-moment.js"></script>
+	<script type="text/javascript" src="javascripts/ng-tags-input.js"></script>
   </head>
   <body class="container" ng-controller="TrackerController as tracker">
   	<header class="page-header">


### PR DESCRIPTION
completed adding ngTagsInput support.  The expenses schema was updated to store both an ngTags field as well as tags which are the legacy text tags.. Both remain as tag filtering was already coded to pull from the legacy tags and a mechanism is in place to make sure both are populated going forward.. A data migration program was written to populate the ngTags field for the existing data entries

![image](https://cloud.githubusercontent.com/assets/10508962/5942496/9dad9adc-a6dd-11e4-936c-ad9d7ed46dd7.png)
